### PR TITLE
Initial eth-docker integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wagyuinstaller",
   "productName": "Wagyu Installer",
-  "version": "0.5",
+  "version": "0.5.0",
   "description": "Application aimed at lowering the technical bar to staking on Ethereum",
   "main": "./build/electron/index.js",
   "author": "Colfax Selby <colfax.selby@gmail.com>",
@@ -10,7 +10,6 @@
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",
-    "@types/tmp": "^0.2.2",
     "css-loader": "^6.7.0",
     "electron": "^17.1.0",
     "electron-builder": "^22.14.5",
@@ -33,13 +32,15 @@
     "@fontsource/roboto": "^4.5.3",
     "@mui/icons-material": "^5.4.4",
     "@mui/material": "^5.4.4",
+    "command-join": "^3.0.0",
     "git-revision-webpack-plugin": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.2",
     "shebang-loader": "^0.0.1",
-    "sudo-prompt": "^9.2.1"
+    "sudo-prompt": "^9.2.1",
+    "tmp-promise": "^3.0.3"
   },
   "build": {
     "appId": "gg.wagyu.installer",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.2",
-    "shebang-loader": "^0.0.1"
+    "shebang-loader": "^0.0.1",
+    "sudo-prompt": "^9.2.1"
   },
   "build": {
     "appId": "gg.wagyu.installer",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@mui/icons-material": "^5.4.4",
     "@mui/material": "^5.4.4",
     "command-join": "^3.0.0",
+    "generate-password": "^1.7.0",
     "git-revision-webpack-plugin": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "react": "^17.0.2",

--- a/src/electron/BashUtils.ts
+++ b/src/electron/BashUtils.ts
@@ -13,8 +13,6 @@ import { access, stat } from 'fs/promises';
 
 import path from "path";
 
-import { fileSync } from "tmp";
-
 const readdirProm = promisify(readdir);
 
 /**
@@ -48,35 +46,6 @@ const doesDirectoryExist = async (directory: string): Promise<boolean> => {
 }
 
 /**
- * Check if we can write a file in a directory.
- * 
- * @param directory The path to the directory.
- * 
- * @returns Returns true if the directory is writable and if a file can be written in the
- *          directory. Returns false if not.
- */
-const isDirectoryWritable = async (directory: string): Promise<boolean> => {
-  let tempFile = null;
-  try {
-    await access(directory, constants.W_OK);
-
-    /**
-    * On Windows, checking for W_OK on a directory is not enough to tell if we can write a file in
-    * it. We need to actually write a temporary file to check.
-    */
-    tempFile = fileSync({ keep: false, tmpdir: directory });
-
-    return true;
-  } catch (err) {
-    return false;
-  } finally {
-    if (tempFile != null) {
-      tempFile.removeCallback();
-    }
-  }
-}
-
-/**
  * Find the first file whom filename starts with some value in a directory.
  * 
  * @param directory The path to the directory.
@@ -100,6 +69,5 @@ const findFirstFile = async (directory: string, startsWith: string): Promise<str
 export {
   doesFileExist,
   doesDirectoryExist,
-  isDirectoryWritable,
   findFirstFile
 };

--- a/src/electron/EthDockerInstaller.ts
+++ b/src/electron/EthDockerInstaller.ts
@@ -1,11 +1,84 @@
-import { ExecutionClient, ConsensusClient, IMultiClientInstaller, KeyImportResult, NodeStatus, ValidatorStatus } from "./IMultiClientInstaller";
+import sudo from 'sudo-prompt';
+
+import {
+  ExecutionClient,
+  ConsensusClient,
+  IMultiClientInstaller,
+  KeyImportResult,
+  NodeStatus,
+  ValidatorStatus
+} from "./IMultiClientInstaller";
 
 export class EthDockerInstaller implements IMultiClientInstaller {
 
-  async preInstall(): Promise<void> {
+  title = 'Electron';
+
+  async preInstall(): Promise<boolean> {
+    console.log('preInstall called');
+    // We need updated packages
+
+    if (!await this.ubuntuAptUpdate()) {
+      return false;
+    };
+
+    // We need git installed
+
+    const gitPackageName = 'git';
+
+    const gitInstalled = await this.checkForInstalledUbuntuPackage(gitPackageName);
+    if (!gitInstalled) {
+      if (!await this.installUbuntuPackage(gitPackageName)) {
+        return false;
+      }
+    }
+
+    // We need docker installed
+
+    const dockerPackageName = 'docker-compose';
+
+    const dockerInstalled = await this.checkForInstalledUbuntuPackage(dockerPackageName);
+    if (!dockerInstalled) {
+      if (!await this.installUbuntuPackage(dockerPackageName)) {
+        return false;
+      }
+    }
+
+    // TODO: We need docker service enabled
+    // TODO: We need our user to be in docker group
+    return false;
+  }
+
+  async ubuntuAptUpdate(): Promise<boolean> {
+    console.log('ubuntuAptUpdate called')
+    const promise = new Promise<boolean>((resolve, reject) => {
+      const options = {
+        name: this.title
+      };
+      try {
+        sudo.exec('apt -y update', options,
+          function (error, stdout, stderr) {
+            if (error) throw error;
+            console.log(stdout);
+            resolve(true);
+          }
+        );
+      } catch (error) {
+        resolve(false);
+      }
+    });
+    return promise;
+  }
+
+  async checkForInstalledUbuntuPackage(packageName: string): Promise<boolean> {
+    console.log('checkForInstalledUbuntuPackage called')
     // TODO: implement
-    console.log("Executing preInstall");
-    return;
+    return false;
+  }
+
+  async installUbuntuPackage(packageName: string): Promise<boolean> {
+    console.log('installUbuntuPackage called')
+    // TODO: implement
+    return false;
   }
 
   async install(): Promise<void> {

--- a/src/electron/EthDockerInstaller.ts
+++ b/src/electron/EthDockerInstaller.ts
@@ -283,8 +283,8 @@ export class EthDockerInstaller implements IMultiClientInstaller {
       }
     }
 
-    // Clone repository if needed
     if (needToClone) {
+      // Clone repository if needed
       const execProm = execFileProm('git', ['clone', ethDockerGitRepository], { cwd: networkPath });
       const { stdout, stderr } = await execProm;
 
@@ -292,15 +292,15 @@ export class EthDockerInstaller implements IMultiClientInstaller {
         console.log('We failed to clone eth-docker repository.');
         return false;
       }
-    }
+    } else {
+      // Update repository
+      const execProm = execFileProm('git', ['pull'], { cwd: ethDockerPath });
+      const { stdout, stderr } = await execProm;
 
-    // Update repository
-    const execProm = execFileProm('git', ['pull'], { cwd: ethDockerPath });
-    const { stdout, stderr } = await execProm;
-
-    if (execProm.child.exitCode !== 0) {
-      console.log('We failed to update eth-docker repository.');
-      return false;
+      if (execProm.child.exitCode !== 0) {
+        console.log('We failed to update eth-docker repository.');
+        return false;
+      }
     }
 
     return true;

--- a/src/electron/EthDockerInstaller.ts
+++ b/src/electron/EthDockerInstaller.ts
@@ -410,20 +410,52 @@ EONG
     return true;
   }
 
-  async postInstall(): Promise<boolean> {
-    return this.startNodes();
+  async postInstall(network: Network): Promise<boolean> {
+    return this.startNodes(network);
   }
 
-  async stopNodes(): Promise<boolean> {
-    // TODO: implement
-    console.log("Executing stopNodes");
-    return false;
+  async stopNodes(network: Network): Promise<boolean> {
+    const networkPath = path.join(installPath, network.toLowerCase());
+    const ethDockerPath = path.join(networkPath, 'eth-docker');
+
+    const ethdCommand = path.join(ethDockerPath, 'ethd');
+    const bashScript = `
+/usr/bin/newgrp ${dockerGroupName} <<EONG
+${ethdCommand} stop
+EONG
+    `;
+
+    const returnProm = execProm(bashScript, { shell: '/bin/bash', cwd: ethDockerPath });
+    const { stdout, stderr } = await returnProm;
+
+    if (returnProm.child.exitCode !== 0) {
+      console.log('We failed to stop eth-docker clients.');
+      return false;
+    }
+
+    return true;
   }
 
-  async startNodes(): Promise<boolean> {
-    // TODO: implement
-    console.log("Executing startNodes");
-    return false;
+  async startNodes(network: Network): Promise<boolean> {
+    const networkPath = path.join(installPath, network.toLowerCase());
+    const ethDockerPath = path.join(networkPath, 'eth-docker');
+
+    const ethdCommand = path.join(ethDockerPath, 'ethd');
+    const bashScript = `
+/usr/bin/newgrp ${dockerGroupName} <<EONG
+${ethdCommand} start
+EONG
+    `;
+
+    const returnProm = execProm(bashScript, { shell: '/bin/bash', cwd: ethDockerPath });
+    const { stdout, stderr } = await returnProm;
+
+    if (returnProm.child.exitCode !== 0) {
+      console.log('We failed to start eth-docker clients.');
+      return false;
+    }
+
+    return true;
   }
 
   async updateExecutionClient(): Promise<void> {

--- a/src/electron/IMultiClientInstaller.ts
+++ b/src/electron/IMultiClientInstaller.ts
@@ -50,7 +50,8 @@ export interface IMultiClientInstaller {
 export type InstallDetails = {
   network: Network,
   executionClient: ExecutionClient,
-  consensusClient: ConsensusClient
+  consensusClient: ConsensusClient,
+  keyDirectory: string
 }
 
 export type KeyImportResult = {
@@ -76,6 +77,8 @@ export enum ValidatorStatus {
 export enum ExecutionClient {
   GETH = "geth",
   NETHERMIND = "nethermind",
+  BESU = "besu",
+  ERIGON = "erigon"
 }
 
 export enum ConsensusClient {
@@ -83,4 +86,5 @@ export enum ConsensusClient {
   NIMBUS = "nimbus",
   LIGHTHOUSE = "lighthouse",
   PRYSM = "prysm",
+  LODESTAR = "lodestar"
 }

--- a/src/electron/IMultiClientInstaller.ts
+++ b/src/electron/IMultiClientInstaller.ts
@@ -5,10 +5,10 @@ export interface IMultiClientInstaller {
   // Functionality
   preInstall: () => Promise<boolean>,
   install: (details: InstallDetails) => Promise<boolean>,
-  postInstall: () => Promise<boolean>,
+  postInstall: (network: Network) => Promise<boolean>,
 
-  stopNodes: () => Promise<boolean>,
-  startNodes: () => Promise<boolean>,
+  stopNodes: (network: Network) => Promise<boolean>,
+  startNodes: (network: Network) => Promise<boolean>,
 
   updateExecutionClient: () => Promise<void>,
   updateConsensusClient: () => Promise<void>,

--- a/src/electron/IMultiClientInstaller.ts
+++ b/src/electron/IMultiClientInstaller.ts
@@ -5,21 +5,24 @@ export interface IMultiClientInstaller {
   // Functionality
   preInstall: () => Promise<boolean>,
   install: (details: InstallDetails) => Promise<boolean>,
-  postInstall: () => Promise<void>,
+  postInstall: () => Promise<boolean>,
 
-  stopNodes: () => Promise<void>,
-  startNodes: () => Promise<void>,
+  stopNodes: () => Promise<boolean>,
+  startNodes: () => Promise<boolean>,
 
   updateExecutionClient: () => Promise<void>,
   updateConsensusClient: () => Promise<void>,
 
-  importKeys: (keyStorePaths: string[]) => Promise<KeyImportResult[]>,
-  exportKeys: (keyStorePaths: string[]) => Promise<KeyImportResult[]>,
+  importKeys: (
+    network: Network,
+    keyStoreDirectoryPath: string,
+    keyStorePassword: string) => Promise<boolean>,
+  exportKeys: () => Promise<void>,
 
-  switchExecutionClient: (targetClient: ExecutionClient) => Promise<void>,
-  switchConsensusClient: (targetClient: ConsensusClient) => Promise<void>,
+  switchExecutionClient: (targetClient: ExecutionClient) => Promise<boolean>,
+  switchConsensusClient: (targetClient: ConsensusClient) => Promise<boolean>,
 
-  uninstall: () => Promise<void>,
+  uninstall: () => Promise<boolean>,
 
 
   // Data
@@ -51,12 +54,6 @@ export type InstallDetails = {
   network: Network,
   executionClient: ExecutionClient,
   consensusClient: ConsensusClient,
-  keysDirectory: string
-}
-
-export type KeyImportResult = {
-  path: string,
-  success: boolean,
 }
 
 export enum NodeStatus {

--- a/src/electron/IMultiClientInstaller.ts
+++ b/src/electron/IMultiClientInstaller.ts
@@ -1,7 +1,7 @@
 export interface IMultiClientInstaller {
 
   // Functionality
-  preInstall: () => Promise<void>,
+  preInstall: () => Promise<boolean>,
   install: () => Promise<void>,
   postInstall: () => Promise<void>,
 

--- a/src/electron/IMultiClientInstaller.ts
+++ b/src/electron/IMultiClientInstaller.ts
@@ -1,8 +1,10 @@
+import { Network } from "../react/types"
+
 export interface IMultiClientInstaller {
 
   // Functionality
   preInstall: () => Promise<boolean>,
-  install: () => Promise<void>,
+  install: (details: InstallDetails) => Promise<boolean>,
   postInstall: () => Promise<void>,
 
   stopNodes: () => Promise<void>,
@@ -43,6 +45,12 @@ export interface IMultiClientInstaller {
   consensusClientLatestBlock: () => Promise<number>,
 
   // TODO: logs stream
+}
+
+export type InstallDetails = {
+  network: Network,
+  executionClient: ExecutionClient,
+  consensusClient: ConsensusClient
 }
 
 export type KeyImportResult = {

--- a/src/electron/IMultiClientInstaller.ts
+++ b/src/electron/IMultiClientInstaller.ts
@@ -51,7 +51,7 @@ export type InstallDetails = {
   network: Network,
   executionClient: ExecutionClient,
   consensusClient: ConsensusClient,
-  keyDirectory: string
+  keysDirectory: string
 }
 
 export type KeyImportResult = {

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -27,7 +27,7 @@ const doesFileExist = (filename: string): boolean => {
 app.on("ready", () => {
   var iconPath = path.join("static", "icon.png");
   const bundledIconPath = path.join(process.resourcesPath, "..", "static", "icon.png");
-  
+
   if (doesFileExist(bundledIconPath)) {
     iconPath = bundledIconPath;
   }
@@ -66,10 +66,10 @@ app.on("ready", () => {
    * Allow for refreshing of the React app within Electron without reopening.
    * This feature is used for development and will be disabled before production deployment.
    */
-	globalShortcut.register('CommandOrControl+R', function() {
-		console.log('CommandOrControl+R was pressed, refreshing the React app within Electron.')
-		window.reload()
-	})
+  globalShortcut.register('CommandOrControl+R', function () {
+    console.log('CommandOrControl+R was pressed, refreshing the React app within Electron.')
+    window.reload()
+  })
 
   /**
    * This logic closes the application when the window is closed, explicitly.
@@ -83,7 +83,7 @@ app.on("ready", () => {
    * Provides the renderer a way to call the dialog.showOpenDialog function using IPC.
    */
   ipcMain.handle('showOpenDialog', async (event, options) => {
-    return await dialog.showOpenDialog(<OpenDialogOptions> options);
+    return await dialog.showOpenDialog(<OpenDialogOptions>options);
   });
 
   /**

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -31,6 +31,15 @@ const ethDockerImportKeys = async (
   keyStorePassword: string): Promise<boolean> => {
   return ethDockerInstaller.importKeys(network, keyStoreDirectoryPath, keyStorePassword);
 };
+const ethDockerPostInstall = async (network: Network): Promise<boolean> => {
+  return ethDockerInstaller.postInstall(network);
+};
+const ethDockerStartNodes = async (network: Network): Promise<boolean> => {
+  return ethDockerInstaller.startNodes(network);
+};
+const ethDockerStopNodes = async (network: Network): Promise<boolean> => {
+  return ethDockerInstaller.stopNodes(network);
+};
 
 const ipcRendererSendClose = () => {
   ipcRenderer.send('close');
@@ -56,5 +65,8 @@ contextBridge.exposeInMainWorld('bashUtils', {
 contextBridge.exposeInMainWorld('ethDocker', {
   'preInstall': ethDockerPreInstall,
   'install': ethDockerInstall,
-  'importKeys': ethDockerImportKeys
+  'importKeys': ethDockerImportKeys,
+  'postInstall': ethDockerPostInstall,
+  'startNodes': ethDockerStartNodes,
+  'stopNodes': ethDockerStopNodes
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -14,6 +14,14 @@ import {
 
 import { doesDirectoryExist, isDirectoryWritable, findFirstFile } from './BashUtils';
 
+import { EthDockerInstaller } from './EthDockerInstaller';
+
+const ethDockerInstaller = new EthDockerInstaller();
+const preInstall = async (): Promise<boolean> => {
+  console.log('IPC preInstall called');
+  return ethDockerInstaller.preInstall();
+}
+
 const ipcRendererSendClose = () => {
   ipcRenderer.send('close');
 };
@@ -34,4 +42,9 @@ contextBridge.exposeInMainWorld('bashUtils', {
   'doesDirectoryExist': doesDirectoryExist,
   'isDirectoryWritable': isDirectoryWritable,
   'findFirstFile': findFirstFile
+});
+
+console.log('exposeInMainWorld');
+contextBridge.exposeInMainWorld('ethDocker', {
+  'preInstall': preInstall
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -11,6 +11,7 @@ import {
   OpenDialogOptions,
   OpenDialogReturnValue
 } from "electron";
+import { Network } from "../react/types";
 
 import { doesDirectoryExist, findFirstFile } from './BashUtils';
 
@@ -20,10 +21,16 @@ import { InstallDetails } from "./IMultiClientInstaller";
 const ethDockerInstaller = new EthDockerInstaller();
 const ethDockerPreInstall = async (): Promise<boolean> => {
   return ethDockerInstaller.preInstall();
-}
+};
 const ethDockerInstall = async (details: InstallDetails): Promise<boolean> => {
   return ethDockerInstaller.install(details);
-}
+};
+const ethDockerImportKeys = async (
+  network: Network,
+  keyStoreDirectoryPath: string,
+  keyStorePassword: string): Promise<boolean> => {
+  return ethDockerInstaller.importKeys(network, keyStoreDirectoryPath, keyStorePassword);
+};
 
 const ipcRendererSendClose = () => {
   ipcRenderer.send('close');
@@ -46,8 +53,8 @@ contextBridge.exposeInMainWorld('bashUtils', {
   'findFirstFile': findFirstFile
 });
 
-console.log('exposeInMainWorld');
 contextBridge.exposeInMainWorld('ethDocker', {
   'preInstall': ethDockerPreInstall,
-  'install': ethDockerInstall
+  'install': ethDockerInstall,
+  'importKeys': ethDockerImportKeys
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -12,13 +12,12 @@ import {
   OpenDialogReturnValue
 } from "electron";
 
-import { doesDirectoryExist, isDirectoryWritable, findFirstFile } from './BashUtils';
+import { doesDirectoryExist, findFirstFile } from './BashUtils';
 
 import { EthDockerInstaller } from './EthDockerInstaller';
 
 const ethDockerInstaller = new EthDockerInstaller();
-const preInstall = async (): Promise<boolean> => {
-  console.log('IPC preInstall called');
+const ethDockerPreInstall = async (): Promise<boolean> => {
   return ethDockerInstaller.preInstall();
 }
 
@@ -40,11 +39,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
 contextBridge.exposeInMainWorld('bashUtils', {
   'doesDirectoryExist': doesDirectoryExist,
-  'isDirectoryWritable': isDirectoryWritable,
   'findFirstFile': findFirstFile
 });
 
 console.log('exposeInMainWorld');
 contextBridge.exposeInMainWorld('ethDocker', {
-  'preInstall': preInstall
+  'preInstall': ethDockerPreInstall
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -15,10 +15,14 @@ import {
 import { doesDirectoryExist, findFirstFile } from './BashUtils';
 
 import { EthDockerInstaller } from './EthDockerInstaller';
+import { InstallDetails } from "./IMultiClientInstaller";
 
 const ethDockerInstaller = new EthDockerInstaller();
 const ethDockerPreInstall = async (): Promise<boolean> => {
   return ethDockerInstaller.preInstall();
+}
+const ethDockerInstall = async (details: InstallDetails): Promise<boolean> => {
+  return ethDockerInstaller.install(details);
 }
 
 const ipcRendererSendClose = () => {
@@ -44,5 +48,6 @@ contextBridge.exposeInMainWorld('bashUtils', {
 
 console.log('exposeInMainWorld');
 contextBridge.exposeInMainWorld('ethDocker', {
-  'preInstall': ethDockerPreInstall
+  'preInstall': ethDockerPreInstall,
+  'install': ethDockerInstall
 });

--- a/src/electron/renderer.d.ts
+++ b/src/electron/renderer.d.ts
@@ -23,6 +23,10 @@ import {
   ChildProcess
 } from "child_process"
 
+import {
+  EthDockerInstaller
+} from './EthDockerInstaller'
+
 export interface IElectronAPI {
   shellOpenExternal: (url: string, options?: Electron.OpenExternalOptions | undefined) => Promise<void>,
   shellShowItemInFolder: (fullPath: string) => void,
@@ -37,9 +41,14 @@ export interface IBashUtilsAPI {
   findFirstFile: (directory: string, startsWith: string) => Promise<string>
 }
 
+export interface IEthDockerAPI {
+  preInstall: () => Promise<boolean>
+}
+
 declare global {
   interface Window {
     electronAPI: IElectronAPI,
-    bashUtils: IBashUtilsAPI
+    bashUtils: IBashUtilsAPI,
+    ethDocker: IEthDockerAPI
   }
 }

--- a/src/electron/renderer.d.ts
+++ b/src/electron/renderer.d.ts
@@ -26,6 +26,7 @@ import {
 import {
   EthDockerInstaller
 } from './EthDockerInstaller'
+import { InstallDetails } from "./IMultiClientInstaller";
 
 export interface IElectronAPI {
   shellOpenExternal: (url: string, options?: Electron.OpenExternalOptions | undefined) => Promise<void>,
@@ -42,7 +43,8 @@ export interface IBashUtilsAPI {
 }
 
 export interface IEthDockerAPI {
-  preInstall: () => Promise<boolean>
+  preInstall: () => Promise<boolean>,
+  install: (details: InstallDetails) => Promise<boolean>
 }
 
 declare global {

--- a/src/electron/renderer.d.ts
+++ b/src/electron/renderer.d.ts
@@ -49,7 +49,10 @@ export interface IEthDockerAPI {
   importKeys: (
     network: Network,
     keyStoreDirectoryPath: string,
-    keyStorePassword: string) => Promise<boolean>
+    keyStorePassword: string) => Promise<boolean>,
+  postInstall: (network: Network) => Promise<boolean>,
+  startNodes: (network: Network) => Promise<boolean>,
+  stopNodes: (network: Network) => Promise<boolean>,
 }
 
 declare global {

--- a/src/electron/renderer.d.ts
+++ b/src/electron/renderer.d.ts
@@ -42,9 +42,14 @@ export interface IBashUtilsAPI {
   findFirstFile: (directory: string, startsWith: string) => Promise<string>
 }
 
+
 export interface IEthDockerAPI {
   preInstall: () => Promise<boolean>,
-  install: (details: InstallDetails) => Promise<boolean>
+  install: (details: InstallDetails) => Promise<boolean>,
+  importKeys: (
+    network: Network,
+    keyStoreDirectoryPath: string,
+    keyStorePassword: string) => Promise<boolean>
 }
 
 declare global {

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -117,6 +117,13 @@ const Home: FC<HomeProps> = (props): ReactElement => {
               '/home/remy/keys',
               'password').then(importKeysResult => {
                 console.log(`importKeys ${importKeysResult}`);
+
+                if (importKeysResult) {
+                  window.ethDocker.postInstall(props.network).then(postInstallResult => {
+                    console.log(`postInstall ${postInstallResult}`);
+                  });
+                }
+
               });
           }
 

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -98,6 +98,10 @@ const Home: FC<HomeProps> = (props): ReactElement => {
   }
 
   const handleEnter = () => {
+
+    window.ethDocker.preInstall().then(result => console.log(result));
+
+    /*
     setEnterSelected(true);
 
     if (!networkModalWasOpened) {
@@ -108,7 +112,7 @@ const Home: FC<HomeProps> = (props): ReactElement => {
       }
 
       navigate(location);
-    }
+    }*/
   }
 
   const tabIndex = (priority: number) => showNetworkModal ? -1 : priority;

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -106,12 +106,20 @@ const Home: FC<HomeProps> = (props): ReactElement => {
         const installationDetails: InstallDetails = {
           network: props.network,
           executionClient: ExecutionClient.GETH,
-          consensusClient: ConsensusClient.LIGHTHOUSE,
-          keysDirectory: ''
+          consensusClient: ConsensusClient.LIGHTHOUSE
         };
 
         window.ethDocker.install(installationDetails).then(installResult => {
           console.log(`install ${installResult}`);
+          if (installResult) {
+            window.ethDocker.importKeys(
+              props.network,
+              '/home/remy/keys',
+              'password').then(importKeysResult => {
+                console.log(`importKeys ${importKeysResult}`);
+              });
+          }
+
         });
       }
     });

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -106,7 +106,8 @@ const Home: FC<HomeProps> = (props): ReactElement => {
         const installationDetails: InstallDetails = {
           network: props.network,
           executionClient: ExecutionClient.GETH,
-          consensusClient: ConsensusClient.LIGHTHOUSE
+          consensusClient: ConsensusClient.LIGHTHOUSE,
+          keysDirectory: ''
         };
 
         window.ethDocker.install(installationDetails).then(installResult => {

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -6,6 +6,7 @@ import { Button } from '@mui/material';
 import { NetworkPicker } from "../components/NetworkPicker";
 import { Network, StepSequenceKey } from '../types'
 import VersionFooter from "../components/VersionFooter";
+import { ConsensusClient, ExecutionClient, InstallDetails } from "../../electron/IMultiClientInstaller";
 
 const StyledMuiContainer = styled(Container)`
   display: flex;
@@ -99,7 +100,20 @@ const Home: FC<HomeProps> = (props): ReactElement => {
 
   const handleEnter = () => {
 
-    window.ethDocker.preInstall().then(result => console.log(result));
+    window.ethDocker.preInstall().then(preInstallResult => {
+      console.log(`preInstall ${preInstallResult}`);
+      if (preInstallResult) {
+        const installationDetails: InstallDetails = {
+          network: props.network,
+          executionClient: ExecutionClient.GETH,
+          consensusClient: ConsensusClient.LIGHTHOUSE
+        };
+
+        window.ethDocker.install(installationDetails).then(installResult => {
+          console.log(`install ${installResult}`);
+        });
+      }
+    });
 
     /*
     setEnterSelected(true);

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -100,7 +100,8 @@ const Home: FC<HomeProps> = (props): ReactElement => {
 
   const handleEnter = () => {
 
-    window.ethDocker.preInstall().then(preInstallResult => {
+    // Backend usage example
+    /*window.ethDocker.preInstall().then(preInstallResult => {
       console.log(`preInstall ${preInstallResult}`);
       if (preInstallResult) {
         const installationDetails: InstallDetails = {
@@ -129,9 +130,8 @@ const Home: FC<HomeProps> = (props): ReactElement => {
 
         });
       }
-    });
+    });*/
 
-    /*
     setEnterSelected(true);
 
     if (!networkModalWasOpened) {
@@ -142,7 +142,7 @@ const Home: FC<HomeProps> = (props): ReactElement => {
       }
 
       navigate(location);
-    }*/
+    }
   }
 
   const tabIndex = (priority: number) => showNetworkModal ? -1 : priority;

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -12,3 +12,13 @@ export enum Network {
   PRATER = "Prater",
   MAINNET = "Mainnet"
 }
+
+export enum ExecutionNetwork {
+  GOERLI = "goerli",
+  MAINNET = "mainnet"
+}
+
+export const networkToExecution: Map<Network, ExecutionNetwork> = new Map([
+  [Network.PRATER, ExecutionNetwork.GOERLI],
+  [Network.MAINNET, ExecutionNetwork.MAINNET]
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,6 +2552,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generate-password@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "generate-password@npm:1.7.0"
+  checksum: c0d13e9a9c72d84adc4365a0c0dbd28463f2da1975b4ec83f34a126b95122551274755db641418e5aa11c8d94c1d216c8da8314f38e56e05378e1a43792f4614
+  languageName: node
+  linkType: hard
+
 "get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
@@ -5102,6 +5109,7 @@ __metadata:
     css-loader: ^6.7.0
     electron: ^17.1.0
     electron-builder: ^22.14.5
+    generate-password: ^1.7.0
     git-revision-webpack-plugin: ^5.0.0
     html-webpack-plugin: ^5.5.0
     react: ^17.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4714,6 +4714,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sudo-prompt@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "sudo-prompt@npm:9.2.1"
+  checksum: 50a29eec2f264f2b78d891452a64112d839a30bffbff4ec065dba4af691a35b23cdb8f9107d413e25c1a9f1925644a19994c00602495cab033d53f585fdfd665
+  languageName: node
+  linkType: hard
+
 "sumchecker@npm:^3.0.1":
   version: 3.0.1
   resolution: "sumchecker@npm:3.0.1"
@@ -5093,6 +5100,7 @@ __metadata:
     react-router-dom: ^6.2.2
     shebang-loader: ^0.0.1
     style-loader: ^3.3.1
+    sudo-prompt: ^9.2.1
     ts-loader: ^9.2.3
     typescript: ^4.3.5
     webpack: ^5.64.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,6 +296,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@improved/node@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@improved/node@npm:1.1.1"
+  checksum: 39dca64da0e948c3595dd1966428948abb091e5ebc28ad0829b914afa026a0ede5b43ba1f3e5b32d576ab0346695b0f582652d686aed2fdd063a59178713820c
+  languageName: node
+  linkType: hard
+
 "@malept/cross-spawn-promise@npm:^1.1.0":
   version: 1.1.1
   resolution: "@malept/cross-spawn-promise@npm:1.1.1"
@@ -739,13 +746,6 @@ __metadata:
   version: 0.16.2
   resolution: "@types/scheduler@npm:0.16.2"
   checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
-  languageName: node
-  linkType: hard
-
-"@types/tmp@npm:^0.2.2":
-  version: 0.2.3
-  resolution: "@types/tmp@npm:0.2.3"
-  checksum: 0ca45e99b3b3c6959d5c4f4555f73c8007db540cfb0fbbb9373217f9ab85e67eef75193f51a1d6564b0ee6c6f5ffa259d1034d7f7530a5b7ce80acb94cfc4daa
   languageName: node
   linkType: hard
 
@@ -1657,6 +1657,15 @@ __metadata:
   dependencies:
     delayed-stream: ~1.0.0
   checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
+  languageName: node
+  linkType: hard
+
+"command-join@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "command-join@npm:3.0.0"
+  dependencies:
+    "@improved/node": ^1.0.0
+  checksum: afdfe94848dc3a78d98e0cf22e685c6456ab835c8fcf6ac00f5862a3f186cb722ae975c1826d6ce2183edefaf0a0a7b84f5402657b2b1ac380e61f7be09cdebd
   languageName: node
   linkType: hard
 
@@ -4835,7 +4844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp-promise@npm:^3.0.2":
+"tmp-promise@npm:^3.0.2, tmp-promise@npm:^3.0.3":
   version: 3.0.3
   resolution: "tmp-promise@npm:3.0.3"
   dependencies:
@@ -5089,7 +5098,7 @@ __metadata:
     "@types/react": ^17.0.14
     "@types/react-dom": ^17.0.9
     "@types/react-router-dom": ^5.1.8
-    "@types/tmp": ^0.2.2
+    command-join: ^3.0.0
     css-loader: ^6.7.0
     electron: ^17.1.0
     electron-builder: ^22.14.5
@@ -5101,6 +5110,7 @@ __metadata:
     shebang-loader: ^0.0.1
     style-loader: ^3.3.1
     sudo-prompt: ^9.2.1
+    tmp-promise: ^3.0.3
     ts-loader: ^9.2.3
     typescript: ^4.3.5
     webpack: ^5.64.3


### PR DESCRIPTION
This includes initial implementation with `preInstall`, `install`, `postInstall`, `stopNodes`, `startNodes`, `importKeys` for Ubuntu 20.04 desktop.

Example usage of the backend is in `Home.tsx`. You have to bake in some configurations to use it.

Part of #87 